### PR TITLE
Fix initialization comment wording

### DIFF
--- a/bitcount.cpp
+++ b/bitcount.cpp
@@ -160,7 +160,7 @@ int main()
 {
 	srand48(time(NULL));
 	
-	// pre-calc lookup tables
+	// precompute lookup tables
 	{
 		StopWatch sw;
 		sw.Start();


### PR DESCRIPTION
## Summary
- reword the lookup-table initialization comment

## Testing
- `g++ -std=c++11 -O3 bitcount.cpp -o bitcount && ./bitcount`

------
https://chatgpt.com/codex/tasks/task_e_683fb5a8ff448332bee289804ac73542