### PR TITLE
Fix bench variable type

### DIFF
--- a/bitcount.cpp
+++ b/bitcount.cpp
@@ -44,7 +44,7 @@ void run_test(const unsigned int iters, bc_function bcf, const char* name)
 	StopWatch sw;
 	sw.Start();
 	
-	int num_of_bits = 0;
+        unsigned long long num_of_bits = 0;
 	for(unsigned int i = 0; i < iters; ++i)
 	{
 		num_of_bits += (*bcf)(lrand48());


### PR DESCRIPTION
## Summary
- use unsigned long long for the benchmark accumulator

## Testing
- `make bench`

------
https://chatgpt.com/codex/tasks/task_e_68406ffc627c83329edf7c6429274b74