### PR TITLE
Add explicit value checks to tests

### DIFF
--- a/bitcount_test.cpp
+++ b/bitcount_test.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 #include <random>
 #include <iostream>
+#include <vector>
 
 #include "bitcount_algorithms.h"
 
@@ -12,21 +13,13 @@ int main() {
     std::mt19937 rng(12345);
     const int trials = 100000;
 
-    // Verify a few explicit values first
-    const unsigned int test_values[] = {0u, 1u, 0xFFFFFFFFu};
-    for (unsigned int value : test_values) {
-        int ref = __builtin_popcount(value);
-        assert(bitcount(value) == ref);
-        assert(bitcount_sparse(value) == ref);
-        assert(bitcount_dense(value) == ref);
-        assert(bitcount_precomp8(value) == ref);
-        assert(bitcount_precomp16(value) == ref);
-        assert(bitcount_parallel(value) == ref);
-        assert(bitcount_nifty(value) == ref);
-        assert(bitcount_hakmem(value) == ref);
-    }
+    std::vector<unsigned int> test_values = {0u, 1u, 0xFFFFFFFFu};
+    test_values.reserve(trials + test_values.size());
     for (int i = 0; i < trials; ++i) {
-        unsigned int value = rng();
+        test_values.push_back(rng());
+    }
+
+    for (unsigned int value : test_values) {
         int ref = __builtin_popcount(value);
         assert(bitcount(value) == ref);
         assert(bitcount_sparse(value) == ref);

--- a/bitcount_test.cpp
+++ b/bitcount_test.cpp
@@ -11,6 +11,20 @@ int main() {
 
     std::mt19937 rng(12345);
     const int trials = 100000;
+
+    // Verify a few explicit values first
+    const unsigned int test_values[] = {0u, 1u, 0xFFFFFFFFu};
+    for (unsigned int value : test_values) {
+        int ref = __builtin_popcount(value);
+        assert(bitcount(value) == ref);
+        assert(bitcount_sparse(value) == ref);
+        assert(bitcount_dense(value) == ref);
+        assert(bitcount_precomp8(value) == ref);
+        assert(bitcount_precomp16(value) == ref);
+        assert(bitcount_parallel(value) == ref);
+        assert(bitcount_nifty(value) == ref);
+        assert(bitcount_hakmem(value) == ref);
+    }
     for (int i = 0; i < trials; ++i) {
         unsigned int value = rng();
         int ref = __builtin_popcount(value);


### PR DESCRIPTION
## Summary
- add explicit test cases for fixed integer values
- verify each bitcount function returns same result as `__builtin_popcount`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68407009746883329bf3cfb12991564e