### PR TITLE
Add builtin popcount method

### DIFF
--- a/bitcount.cpp
+++ b/bitcount.cpp
@@ -90,6 +90,9 @@ int main()
   run_test(iters, &bitcount_nifty, 	"Nifty");
   run_test(iters, &bitcount_hakmem, 	"Hakmem");
 
+  printf("---> Builtin method\n");
+  run_test(iters, &bitcount_builtin,    "Builtin");
+
   printf("---> Table lookup methods\n");
   run_test(iters, &bitcount_precomp8, "Precomp 8");
   run_test(iters, &bitcount_precomp16, "Precomp 16");

--- a/bitcount_algorithms.cpp
+++ b/bitcount_algorithms.cpp
@@ -85,3 +85,7 @@ int bitcount_hakmem(unsigned int n) {
   tmp = n - ((n >> 1) & 033333333333) - ((n >> 2) & 011111111111);
   return ((tmp + (tmp >> 3)) & 030707070707) % 63;
 }
+
+int bitcount_builtin(unsigned int n) {
+  return __builtin_popcount(n);
+}

--- a/bitcount_algorithms.h
+++ b/bitcount_algorithms.h
@@ -14,5 +14,6 @@ int bitcount_precomp16(unsigned int n);
 int bitcount_parallel(unsigned int n);
 int bitcount_nifty(unsigned int n);
 int bitcount_hakmem(unsigned int n);
+int bitcount_builtin(unsigned int n);
 
 #endif // BITCOUNT_ALGORITHMS_H

--- a/bitcount_test.cpp
+++ b/bitcount_test.cpp
@@ -29,6 +29,7 @@ int main() {
     assert(bitcount_parallel(value) == ref);
     assert(bitcount_nifty(value) == ref);
     assert(bitcount_hakmem(value) == ref);
+    assert(bitcount_builtin(value) == ref);
   }
   std::cout << "All bitcount tests passed!" << std::endl;
   return 0;


### PR DESCRIPTION
## Summary
- implement `bitcount_builtin` using `__builtin_popcount`
- call the builtin method in benchmarking code
- verify builtin via new test assertions

## Testing
- `make test`
- `make bench`
- `./bitcount`

------
https://chatgpt.com/codex/tasks/task_e_6840787292708332ae3748b4456b4b94