### PR TITLE
Add extra bitcount implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX ?= g++
-CXXFLAGS ?= -std=c++11 -O2
+CXXFLAGS ?= -std=c++11 -O2 -msse4.2
 
 BENCH_OBJS = bitcount.o bitcount_algorithms.o
 TEST_OBJS  = bitcount_test.o bitcount_algorithms.o

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bit counting
 
 This small program measures and compares various bit counting algorithms.
+It includes classic bit tests as well as hardware POPCNT, SIMD shuffling,
+prefix-sum masking, de Bruijn scans and large precomputed lookup tables.
 
 More information about different approaches can be found in the following links:
 

--- a/bitcount.cpp
+++ b/bitcount.cpp
@@ -88,6 +88,13 @@ int main()
     sw.Stop();
     printf("16-bit lookup table calculation took %.2f ms\n", (double)sw.ElapsedMicrosec() / 1000);
   }
+  {
+    StopWatch sw;
+    sw.Start();
+    create_precomp24();
+    sw.Stop();
+    printf("24-bit lookup table calculation took %.2f ms\n", (double)sw.ElapsedMicrosec() / 1000);
+  }
 
   const unsigned int iters = 100 * 1000 * 1000;
   std::vector<Result> results;
@@ -104,10 +111,15 @@ int main()
 
   printf("---> Builtin method\n");
   results.push_back({"Builtin",  run_test(iters, &bitcount_builtin, "Builtin")});
+  results.push_back({"POPCNT",   run_test(iters, &bitcount_popcnt, "POPCNT")});
+  results.push_back({"SIMD",     run_test(iters, &bitcount_simd, "SIMD")});
+  results.push_back({"Prefix",   run_test(iters, &bitcount_prefix, "Prefix")});
+  results.push_back({"deBruijn", run_test(iters, &bitcount_debruijn, "deBruijn")});
 
   printf("---> Table lookup methods\n");
   results.push_back({"Precomp 8",  run_test(iters, &bitcount_precomp8, "Precomp 8")});
   results.push_back({"Precomp 16", run_test(iters, &bitcount_precomp16, "Precomp 16")});
+  results.push_back({"Precomp 24", run_test(iters, &bitcount_precomp24, "Precomp 24")});
 
   std::sort(results.begin(), results.end(), [](const Result& a, const Result& b) { return a.mcps > b.mcps; });
   const double slowest = results.back().mcps;

--- a/bitcount_algorithms.h
+++ b/bitcount_algorithms.h
@@ -15,5 +15,12 @@ int bitcount_parallel(unsigned int n);
 int bitcount_nifty(unsigned int n);
 int bitcount_hakmem(unsigned int n);
 int bitcount_builtin(unsigned int n);
+int bitcount_popcnt(unsigned int n);
+int bitcount_simd(unsigned int n);
+int bitcount_prefix(unsigned int n);
+int bitcount_debruijn(unsigned int n);
+
+void create_precomp24();
+int bitcount_precomp24(unsigned int n);
 
 #endif // BITCOUNT_ALGORITHMS_H

--- a/bitcount_test.cpp
+++ b/bitcount_test.cpp
@@ -9,6 +9,7 @@ int main() {
   // Initialize lookup tables for precomputed methods
   create_precomp8();
   create_precomp16();
+  create_precomp24();
 
   std::mt19937 rng(12345);
   const int trials = 100000;
@@ -30,6 +31,11 @@ int main() {
     assert(bitcount_nifty(value) == ref);
     assert(bitcount_hakmem(value) == ref);
     assert(bitcount_builtin(value) == ref);
+    assert(bitcount_popcnt(value) == ref);
+    assert(bitcount_simd(value) == ref);
+    assert(bitcount_prefix(value) == ref);
+    assert(bitcount_debruijn(value) == ref);
+    assert(bitcount_precomp24(value) == ref);
   }
   std::cout << "All bitcount tests passed!" << std::endl;
   return 0;


### PR DESCRIPTION
## Summary
- implement POPCNT, SIMD, prefix-sum, deBruijn and 24-bit lookup algorithms
- build with SSE4.2 to enable intrinsics
- benchmark and tests run the new implementations
- expand README to mention them

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68409de954bc83328dcf39c0edabe8d0