### PR TITLE
Fix SSE-only code on non-x86 platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 CXX ?= g++
-CXXFLAGS ?= -std=c++11 -O2 -msse4.2
+CXXFLAGS_BASE ?= -std=c++11 -O2
+UNAME_M := $(shell uname -m)
+
+ifeq ($(filter x86_64 i386 i686,$(UNAME_M)),)
+CXXFLAGS ?= $(CXXFLAGS_BASE)
+else
+CXXFLAGS ?= $(CXXFLAGS_BASE) -msse4.2
+endif
 
 BENCH_OBJS = bitcount.o bitcount_algorithms.o
 TEST_OBJS  = bitcount_test.o bitcount_algorithms.o

--- a/bitcount_algorithms.cpp
+++ b/bitcount_algorithms.cpp
@@ -90,14 +90,19 @@ int bitcount_builtin(unsigned int n) {
   return __builtin_popcount(n);
 }
 
-#include <nmmintrin.h>
-
+#if defined(__SSE4_2__)
+#  include <nmmintrin.h>
 int bitcount_popcnt(unsigned int n) {
   return _mm_popcnt_u32(n);
 }
+#else
+int bitcount_popcnt(unsigned int n) {
+  return __builtin_popcount(n);
+}
+#endif
 
-#include <tmmintrin.h>
-
+#if defined(__SSSE3__)
+#  include <tmmintrin.h>
 int bitcount_simd(unsigned int n) {
   const __m128i lookup = _mm_setr_epi8(
     0, 1, 1, 2, 1, 2, 2, 3,
@@ -114,6 +119,11 @@ int bitcount_simd(unsigned int n) {
   int total = _mm_extract_epi16(sad, 0) + _mm_extract_epi16(sad, 4);
   return total / 4;
 }
+#else
+int bitcount_simd(unsigned int n) {
+  return __builtin_popcount(n);
+}
+#endif
 
 int bitcount_prefix(unsigned int n) {
   n -= (n >> 1) & 0x55555555u;


### PR DESCRIPTION
## Summary
- detect CPU architecture in Makefile and only enable `-msse4.2` on x86
- guard SSE implementations with `__SSE4_2__` and `__SSSE3__`
- provide builtin fallbacks when SSE isn't available

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68409ff4f6a8833299af00b6eeab0788